### PR TITLE
feat: adding config and logging for no jackets

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -6,6 +6,7 @@ lazy val scalaTestVersion = "3.1.4"
 lazy val scalaTestPlusMockitoVersion = "3.2.10.0"
 lazy val scalaLoggingVersion = "3.9.4"
 lazy val logbackVersion = "1.2.3"
+lazy val pureConfigVersion = "0.17.1"
 
 // Run in a separate JVM, to make sure sbt waits until all threads have
 // finished before returning.
@@ -25,7 +26,10 @@ lazy val root = (project in file(".")).
       "com.typesafe.akka" %% "akka-http-spray-json"     % akkaHttpVersion,
       "com.typesafe.akka" %% "akka-actor-typed"         % akkaVersion,
       "com.typesafe.akka" %% "akka-stream"              % akkaVersion,
+
       "ch.qos.logback"    % "logback-classic"           % logbackVersion,
+      "com.typesafe.scala-logging" %% "scala-logging"   % scalaLoggingVersion,
+      "com.github.pureconfig" %% "pureconfig"           % pureConfigVersion,
 
       "com.typesafe.akka" %% "akka-http-testkit"        % akkaHttpVersion             % Test,
       "com.typesafe.akka" %% "akka-actor-testkit-typed" % akkaVersion                 % Test,
@@ -35,9 +39,11 @@ lazy val root = (project in file(".")).
       "io.circe" %% "circe-core"                % circeVersion,
       "io.circe" %% "circe-parser"              % circeVersion,
       "io.circe" %% "circe-generic"             % circeVersion,
-      "de.heikoseeberger" %% "akka-http-circe"  % akkaHttpCirceVersion,
+      "de.heikoseeberger" %% "akka-http-circe"  % akkaHttpCirceVersion
 
-      "com.typesafe.scala-logging" %% "scala-logging"   % scalaLoggingVersion
+
+
+
     )
   )
 

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -3,9 +3,12 @@ kittens{
   port=${?PORT}
   routes {
     # If ask takes more time than this to complete the request is failed
-    ask-timeout = 5s
+    default-request-timeout = 5s
   }
 }
 
-kittens-api-host="http://localhost:8080"
-jackets-api-host="http://localhost:8080"
+external-services {
+  kittens-api-host="http://localhost:8080"
+  jackets-api-host="http://localhost:8080"
+}
+

--- a/src/main/scala/org/example/config/ApplicationConfig.scala
+++ b/src/main/scala/org/example/config/ApplicationConfig.scala
@@ -1,0 +1,18 @@
+package org.example.config
+
+import org.example.config.ApplicationConfig.{ExternalServicesConfig, KittensConfig}
+import pureconfig.ConfigSource
+import pureconfig.generic.auto._
+
+import scala.concurrent.duration.Duration
+
+final case class ApplicationConfig(kittens: KittensConfig, externalServices: ExternalServicesConfig)
+
+object ApplicationConfig {
+  final case class KittensConfig(port: Int, routes: RoutesConfig)
+  final case class RoutesConfig(defaultRequestTimeout: Duration)
+  final case class ExternalServicesConfig(kittensApiHost: String, jacketsApiHost: String)
+
+  def apply(): ApplicationConfig =
+    ConfigSource.default.loadOrThrow[ApplicationConfig]
+}

--- a/src/main/scala/org/example/controllers/KittenMatcherController.scala
+++ b/src/main/scala/org/example/controllers/KittenMatcherController.scala
@@ -9,11 +9,18 @@ import akka.http.scaladsl.server.Directives.complete
 import com.typesafe.scalalogging.LazyLogging
 import io.circe.syntax.EncoderOps
 import de.heikoseeberger.akkahttpcirce.FailFastCirceSupport._
-import scala.concurrent.duration.DurationInt
+
+import scala.concurrent.duration.{Duration, DurationInt}
 import scala.concurrent.{Await, ExecutionContext, Future}
 
-class KittenMatcherController(kittenClient: KittensClient, jacketsClient: JacketsClient, kittenJacketMatcher: KittenJacketMatcherService)(implicit val ec: ExecutionContext) extends LazyLogging {
-  def matchKittenToJackets(kittenId: String): StandardRoute = {
+class KittenMatcherController(
+  kittenClient: KittensClient,
+  jacketsClient: JacketsClient,
+  kittenJacketMatcher: KittenJacketMatcherService
+) (
+  implicit val ec: ExecutionContext
+) extends LazyLogging {
+  def matchKittenToJackets(kittenId: String, timeout: Duration): StandardRoute = {
     val response = for {
       kittenOption <- kittenClient.getKittenById(kittenId)
       res <- kittenOption.fold(Future.successful(complete(StatusCodes.NotFound))) { kitten =>
@@ -21,13 +28,16 @@ class KittenMatcherController(kittenClient: KittensClient, jacketsClient: Jacket
           jackets <- jacketsClient.getAllJackets
           matchingJackets = kittenJacketMatcher.getJacketsForKitten(kitten, jackets)
           result = JacketsDto(matchingJackets, matchingJackets.length)
+          _ = if (matchingJackets.isEmpty) {
+              logger.error(s"No jackets returned for kitten id: $kittenId. Number of initial jackets returned: ${jackets.length}")
+            }
         } yield complete(StatusCodes.OK, result.asJson)
       }
     } yield res
 
     response.recover(err => handleFailure(err))
 
-    Await.result(response, 5.seconds)
+    Await.result(response, timeout)
   }
 
   private def handleFailure(err: Throwable): StandardRoute = {

--- a/src/test/scala/org/example/controllers/KittenMatcherControllerSpec.scala
+++ b/src/test/scala/org/example/controllers/KittenMatcherControllerSpec.scala
@@ -17,16 +17,17 @@ import org.scalatestplus.mockito.MockitoSugar
 import de.heikoseeberger.akkahttpcirce.FailFastCirceSupport._
 import org.example.models.ApplicationError.ExternalApiError
 
+import scala.concurrent.duration.{Duration, DurationInt}
 import scala.concurrent.{ExecutionContext, ExecutionContextExecutor, Future}
 
 class KittenMatcherControllerSpec extends AnyFreeSpec with MockitoSugar with Matchers with ScalatestRouteTest {
   implicit val ec: ExecutionContextExecutor = ExecutionContext.global
 
-  private def generateTestRoute (controllerMethod: String => StandardRoute): Route = {
+  private def generateTestRoute (controllerMethod: (String, Duration) => StandardRoute): Route = {
     get {
       concat(
         path("kitten_jackets" / Remaining) { path =>
-          controllerMethod(path)
+          controllerMethod(path, 5.seconds)
         },
       )
     }


### PR DESCRIPTION
This PR adds:

Config is now loaded via pure config.

Logging is added for the edge case where no jackets are returned